### PR TITLE
Fix patch LoadLibrary

### DIFF
--- a/sfall/main.cpp
+++ b/sfall/main.cpp
@@ -313,12 +313,15 @@ defaultIni:
 static void LoadOriginalDll(DWORD fdwReason) {
 	switch (fdwReason) {
 	case DLL_PROCESS_ATTACH:
-		ddraw.dll = LoadLibraryA("wrapper\\ddraw.dll"); // external DirectDraw wrapper
+		char path[MAX_PATH];
+		GetCurrentDirectory(sizeof(path) - 1, path); // external DirectDraw wrapper
+		_snprintf(path, sizeof(path) - 1, "%s\\wrapper\\ddraw.dll", path);
+		ddraw.dll = LoadLibraryA(path);
 		if (ddraw.dll) {
 			sfall::extWrapper = true;
 		} else {
-			char path[MAX_PATH];
-			CopyMemory(path + GetSystemDirectoryA(path, MAX_PATH - 10), "\\ddraw.dll", 11); // path to original dll
+			GetSystemDirectoryA(path, sizeof(path) - 1); // path to original dll
+			_snprintf(path, sizeof(path) - 1, "%s\\ddraw.dll", path);
 			ddraw.dll = LoadLibraryA(path);
 		}
 		if (ddraw.dll) {


### PR DESCRIPTION
It was like this
![111](https://github.com/sfall-team/sfall/assets/60801856/1a3b22e8-67e5-4109-a0fd-b2b0803783bf)
And it became like this
![222](https://github.com/sfall-team/sfall/assets/60801856/10ddc521-28c3-474c-9537-107349520af9)
