### PR TITLE
Protection against incorrect values and synchronization of graphics mode in ini files

### DIFF
--- a/sfall/HRP/Init.cpp
+++ b/sfall/HRP/Init.cpp
@@ -174,7 +174,7 @@ void Setting::init(const char* exeFileName, std::string &cmdline) {
 	}
 
 	//We neutralize the f2_res.ini file if external HRP is enabled
-	if (Setting::ExternalEnabled() && sf::IniReader::GetInt("Main", "WINDOWED", 404, f2ResIni)) {
+	if (Setting::ExternalEnabled() && sf::IniReader::GetInt("Main", "GRAPHICS_MODE", 404, f2ResIni) > 1) {
 		if (GetFileAttributesA(f2ResIni) == INVALID_FILE_ATTRIBUTES) {
 			//It looks like f2_res.ini is missing, but external HRP is enabled. Let's turn it off just in case.
 			if (!DisableExtHRP(exeFileName, cmdline)) {
@@ -189,9 +189,6 @@ void Setting::init(const char* exeFileName, std::string &cmdline) {
 				? sf::Graphics::mode += 2
 				: sf::Graphics::mode += 1;
 			switch (sf::IniReader::GetInt("Main", "GRAPHICS_MODE", 404, f2ResIni)) {
-			case 1:
-				sf::Graphics::mode += 1; // DD7: 1 or 2/3 (vanilla)
-				break;
 			case 2:
 				sf::Graphics::mode += 4; // DX9: 4 or 5/6 (sfall)
 				break;
@@ -201,9 +198,11 @@ void Setting::init(const char* exeFileName, std::string &cmdline) {
 				break;
 			}
 			sf::IniReader::SetConfigInt("Graphics", "Mode", sf::Graphics::mode);
-			sf::IniReader::SetInt("Main", "GRAPHICS_MODE", 0, f2ResIni);
-			sf::IniReader::SetInt("Main", "WINDOWED", 0, f2ResIni);
-			sf::IniReader::SetInt("Main", "WINDOWED_FULLSCREEN", 0, f2ResIni);
+			if (sf::Graphics::mode > 3) {
+				sf::IniReader::SetInt("Main", "GRAPHICS_MODE", 0, f2ResIni);
+				sf::IniReader::SetInt("Main", "WINDOWED", 0, f2ResIni);
+				sf::IniReader::SetInt("Main", "WINDOWED_FULLSCREEN", 0, f2ResIni);
+			}
 			ShellExecuteA(0, 0, exeFileName, 0, 0, SW_SHOWDEFAULT); // restart game
 			ExitProcess(EXIT_SUCCESS);
 		}
@@ -211,13 +210,29 @@ void Setting::init(const char* exeFileName, std::string &cmdline) {
 
 	if (!Setting::ExternalEnabled() && !hiResMode) return; // vanilla game mode
 
-	SCR_WIDTH = sf::IniReader::GetInt("Main", "SCR_WIDTH", 0, f2ResIni);
-	SCR_HEIGHT = sf::IniReader::GetInt("Main", "SCR_HEIGHT", 0, f2ResIni);
-
-	if (SCR_WIDTH == 0 || SCR_HEIGHT == 0) {
-		SCR_WIDTH = sf::IniReader::GetConfigInt("Graphics", "GraphicsWidth", 640);
-		SCR_HEIGHT = sf::IniReader::GetConfigInt("Graphics", "GraphicsHeight", 480);
+	if (Setting::ExternalEnabled()) {
+		sf::Graphics::mode = sf::IniReader::GetConfigInt("Graphics", "Mode", 0);
+		if (sf::Graphics::mode < 0 || sf::Graphics::mode > 6) {
+			sf::Graphics::mode = 0;
+			sf::IniReader::SetConfigInt("Graphics", "Mode", sf::Graphics::mode);
+		}
+		if (sf::extWrapper && sf::Graphics::mode > 1) sf::Graphics::mode = 1;
+		if (sf::Graphics::mode > 3) sf::Graphics::mode = 0;
 	}
+
+	//This solution is absolutely not suitable for modern FHD/UHD/2K/4K monitors
+	//if (sf::Graphics::mode == 3 || sf::Graphics::mode == 6) {
+	//	SCR_WIDTH = GetSystemMetrics(SM_CXSCREEN);
+	//	SCR_HEIGHT = GetSystemMetrics(SM_CYSCREEN);
+	//} else {
+		SCR_WIDTH = sf::IniReader::GetInt("Main", "SCR_WIDTH", 0, f2ResIni);
+		SCR_HEIGHT = sf::IniReader::GetInt("Main", "SCR_HEIGHT", 0, f2ResIni);
+
+		if (SCR_WIDTH == 0 || SCR_HEIGHT == 0) {
+			SCR_WIDTH = sf::IniReader::GetConfigInt("Graphics", "GraphicsWidth", 640);
+			SCR_HEIGHT = sf::IniReader::GetConfigInt("Graphics", "GraphicsHeight", 480);
+		}
+	//}
 
 	if (SCR_WIDTH < 640) SCR_WIDTH = 640;
 	if (SCR_HEIGHT < 480) SCR_HEIGHT = 480;

--- a/sfall/IniReader.cpp
+++ b/sfall/IniReader.cpp
@@ -180,4 +180,8 @@ int IniReader::SetDefaultConfigString(const char* section, const char* setting, 
 	return instance().setString(section, setting, value, ddrawIni);
 }
 
+int IniReader::SetInt(const char* section, const char* setting, int value, const char* iniFile) {
+	return setInt(section, setting, value, iniFile);
+}
+
 }

--- a/sfall/IniReader.h
+++ b/sfall/IniReader.h
@@ -66,6 +66,8 @@ public:
 
 	static int SetDefaultConfigString(const char* section, const char* setting, const char* value);
 
+	static int SetInt(const char* section, const char* setting, int value, const char* iniFile);
+
 	void init();
 	void clearCache();
 

--- a/sfall/Modules/Graphics.cpp
+++ b/sfall/Modules/Graphics.cpp
@@ -1246,14 +1246,15 @@ static __declspec(naked) void dump_screen_hack_replacement() {
 }
 
 void Graphics::init() {
-	int gMode = (HRP::Setting::ExternalEnabled()) // avoid mode mismatch between ddraw.ini and another ini file
-	          ? IniReader::GetIntDefaultConfig("Graphics", "Mode", 0)
-	          : IniReader::GetConfigInt("Graphics", "Mode", 0);
-	if (gMode >= 4) Graphics::mode = gMode;
-
-	if (extWrapper || Graphics::mode < 0 || Graphics::mode > 6) {
-		Graphics::mode = 0;
+	if (HRP::Setting::ExternalEnabled()) {
+		Graphics::mode = IniReader::GetConfigInt("Graphics", "Mode", 0); // 0/1/2/3/4/5/6 (sfall)
+		if (Graphics::mode < 0 || Graphics::mode > 6) {
+			Graphics::mode = 0;
+			IniReader::SetConfigInt("Graphics", "Mode", Graphics::mode);
+		}
+		if (extWrapper && Graphics::mode > 1) Graphics::mode = 1;
 	}
+
 	Graphics::IsWindowedMode = (Graphics::mode == 2 || Graphics::mode == 3 || Graphics::mode >= 5);
 
 	if (Graphics::mode >= 4) {

--- a/sfall/Modules/Graphics.cpp
+++ b/sfall/Modules/Graphics.cpp
@@ -1246,13 +1246,12 @@ static __declspec(naked) void dump_screen_hack_replacement() {
 }
 
 void Graphics::init() {
-	if (HRP::Setting::ExternalEnabled()) {
-		Graphics::mode = IniReader::GetConfigInt("Graphics", "Mode", 0); // 0/1/2/3/4/5/6 (sfall)
+	if (HRP::Setting::ExternalEnabled() && !Graphics::mode) {
+		Graphics::mode = IniReader::GetConfigInt("Graphics", "Mode", 0); // 4/5/6 (HRP)
 		if (Graphics::mode < 0 || Graphics::mode > 6) {
 			Graphics::mode = 0;
 			IniReader::SetConfigInt("Graphics", "Mode", Graphics::mode);
 		}
-		if (extWrapper && Graphics::mode > 1) Graphics::mode = 1;
 	}
 
 	Graphics::IsWindowedMode = (Graphics::mode == 2 || Graphics::mode == 3 || Graphics::mode >= 5);


### PR DESCRIPTION
You can safely turn on/off the external HRP. The mode settings will always be in the right place.