### PR TITLE
Protection against incorrect graphics mode values, including for external HRP

### DIFF
--- a/sfall/IniReader.cpp
+++ b/sfall/IniReader.cpp
@@ -180,4 +180,8 @@ int IniReader::SetDefaultConfigString(const char* section, const char* setting, 
 	return instance().setString(section, setting, value, ddrawIni);
 }
 
+int IniReader::SetInt(const char* section, const char* setting, int value, const char* iniFile) {
+	return setInt(section, setting, value, iniFile);
+}
+
 }

--- a/sfall/IniReader.h
+++ b/sfall/IniReader.h
@@ -66,6 +66,8 @@ public:
 
 	static int SetDefaultConfigString(const char* section, const char* setting, const char* value);
 
+	static int SetInt(const char* section, const char* setting, int value, const char* iniFile);
+
 	void init();
 	void clearCache();
 

--- a/sfall/Modules/Graphics.cpp
+++ b/sfall/Modules/Graphics.cpp
@@ -1246,16 +1246,6 @@ static __declspec(naked) void dump_screen_hack_replacement() {
 }
 
 void Graphics::init() {
-	int gMode = (HRP::Setting::ExternalEnabled()) // avoid mode mismatch between ddraw.ini and another ini file
-	          ? IniReader::GetIntDefaultConfig("Graphics", "Mode", 0)
-	          : IniReader::GetConfigInt("Graphics", "Mode", 0);
-	if (gMode >= 4) Graphics::mode = gMode;
-
-	if (extWrapper || Graphics::mode < 0 || Graphics::mode > 6) {
-		Graphics::mode = 0;
-	}
-	Graphics::IsWindowedMode = (Graphics::mode == 2 || Graphics::mode == 3 || Graphics::mode >= 5);
-
 	if (Graphics::mode >= 4) {
 		dlog("Applying DX9 graphics patch.", DL_INIT);
 #define _DLL_NAME "d3dx9_43.dll"


### PR DESCRIPTION
This time I checked everything, but I'm not sure about the screen resolution. In the sfall itself it is not very well implemented, but when combined with external HRP it can become even worse.