### PR TITLE
New metarule to read art size + DrawImage refactoring

### DIFF
--- a/artifacts/scripting/functions.yml
+++ b/artifacts/scripting/functions.yml
@@ -1687,6 +1687,16 @@
 - name: Windows and images
   parent: Interface
   items:
+    - name: art_frame_data
+      detail: array art_frame_data(string/int artFile/artId, int frame, int rotation)
+      doc: |
+        - returns dimensions of a given PCX or FRM frame as temp array in form: [width, height]
+        - artFile/artId: path to the PCX/FRM file (e.g. `art\\inven\\5mmap.frm`), or its FRM ID number (e.g. `0x7000026`, see specification of the FID format)
+        optional arguments:
+        - `frame`: frame number, the first frame starts from zero
+        - `rotation`: rotation to get the frame for, useful when reading FRM file by path
+      macro: sfall.h
+      
     - name: interface_art_draw
       detail: int sfall_func4("interface_art_draw", int winType, string artFile/int artID, int x, int y)
       doc: |

--- a/artifacts/scripting/headers/sfall.h
+++ b/artifacts/scripting/headers/sfall.h
@@ -144,9 +144,9 @@
 #define reverse_array(array)        resize_array(array, -4)
 // randomly shuffle elements in list/map
 #define shuffle_array(array)        resize_array(array, -5)
-// sort map in ascending order by key value
+// sort map in ascending order by value
 #define sort_map_value(array)       resize_array(array, -6)
-// sort map in descending order by key value
+// sort map in descending order by value
 #define sort_map_reverse(array)     resize_array(array, -7)
 // remove element from map or just replace value with 0 for list
 #define unset_array(array, key)     set_array(array, key, 0)
@@ -282,6 +282,7 @@
 
 /* SFALL_FUNCX MACROS */
 
+#define FUNC_SELECTOR_4(_1,_2,_3,_4,FUNC,...)                   FUNC
 #define FUNC_SELECTOR_7(_1,_2,_3,_4,_5,_6,_7,FUNC,...)          FUNC
 
 #define add_extra_msg_file(name)                                sfall_func1("add_extra_msg_file", name)
@@ -289,6 +290,7 @@
 #define add_iface_tag                                           sfall_func0("add_iface_tag")
 #define add_trait(traitID)                                      sfall_func1("add_trait", traitID)
 #define art_cache_clear                                         sfall_func0("art_cache_clear")
+#define art_frame_data(art, frame, rot)                         sfall_func3("art_frame_data", art, frame, rot)
 #define attack_is_aimed                                         sfall_func0("attack_is_aimed")
 #define car_gas_amount                                          sfall_func0("car_gas_amount")
 #define clear_window                                            sfall_func0("win_fill_color")
@@ -352,7 +354,11 @@
 #define item_weight(obj)                                        sfall_func1("item_weight", obj)
 #define lock_is_jammed(obj)                                     sfall_func1("lock_is_jammed", obj)
 #define loot_obj                                                sfall_func0("loot_obj")
-#define message_box(text)                                       sfall_func1("message_box", text)
+#define message_box1(text)                                      sfall_func1("message_box", text)
+#define message_box2(text, flags)                               sfall_func2("message_box", text, flags)
+#define message_box3(text, flags, color1)                       sfall_func3("message_box", text, flags, color1)
+#define message_box4(text, flags, color1, color2)               sfall_func4("message_box", text, flags, color1, color2)
+#define message_box(...)                                        FUNC_SELECTOR_4(__VA_ARGS__,message_box4,message_box3,message_box2,message_box1)(__VA_ARGS__)
 #define metarule_exist(metaruleName)                            sfall_func1("metarule_exist", metaruleName)
 #define npc_engine_level_up(toggle)                             sfall_func1("npc_engine_level_up", toggle)
 #define obj_is_openable(obj)                                    sfall_func1("obj_is_openable", obj)

--- a/sfall/FalloutEngine/EngineUtils.cpp
+++ b/sfall/FalloutEngine/EngineUtils.cpp
@@ -233,7 +233,7 @@ long ObjIsOpenable(fo::GameObject* object) {
 	long result = 0;
 	if (fo::func::obj_is_openable(object)) {
 		DWORD lock;
-		fo::FrmHeaderData* frm = fo::func::art_ptr_lock(object->artFid, &lock);
+		fo::FrmFile* frm = fo::func::art_ptr_lock(object->artFid, &lock);
 		if (frm) {
 			if (frm->numFrames > 1) result = 1;
 			fo::func::art_ptr_unlock(lock);

--- a/sfall/FalloutEngine/Functions.cpp
+++ b/sfall/FalloutEngine/Functions.cpp
@@ -404,29 +404,17 @@ void __cdecl trans_buf_to_buf(BYTE* src, long width, long height, long src_width
 	__asm emms;
 }
 
-BYTE* __fastcall loadPCX(const char* file, long* width, long* height) {
-	__asm {
-		mov  eax, ecx;
-		mov  ebx, height;
-		mov  ecx, FO_VAR_pal;
-		call fo::funcoffs::loadPCX_;
-		push eax;
-		mov  ebx, [width];
-		mov  edx, FO_VAR_pal;
-		mov  ecx, [height];
-		mov  ebx, [ebx];
-		mov  ecx, [ecx];
-		call fo::funcoffs::datafileConvertData_;
-		pop  eax;
-	}
-}
-
 long __fastcall get_game_config_string(const char** outValue, const char* section, const char* param) {
 	__asm {
 		mov  ebx, param;
 		mov  eax, FO_VAR_game_config;
 		call fo::funcoffs::config_get_string_; // section<edx>, outValue<ecx>
 	}
+}
+
+void __stdcall freePtr_invoke(void *p) {
+	__asm mov  eax, p;
+	__asm call ds:[FO_VAR_freePtr];
 }
 
 ////////////////////////////////////

--- a/sfall/FalloutEngine/Functions.h
+++ b/sfall/FalloutEngine/Functions.h
@@ -84,9 +84,9 @@ void __cdecl buf_to_buf(BYTE* src, long width, long height, long src_width, BYTE
 // trans_buf_to_buf_ function implementation
 void __cdecl trans_buf_to_buf(BYTE* src, long width, long height, long src_width, BYTE* dst, long dst_width);
 
-BYTE* __fastcall loadPCX(const char* file, long* width, long* height);
-
 long __fastcall get_game_config_string(const char** outValue, const char* section, const char* param);
+
+void __stdcall freePtr_invoke(void *ptr);
 
 // X-Macro for wrapper functions.
 #define WRAP_WATCOM_FUNC0(retType, name) \

--- a/sfall/FalloutEngine/Functions_def.h
+++ b/sfall/FalloutEngine/Functions_def.h
@@ -91,7 +91,8 @@ WRAP_WATCOM_FUNC5(long, art_id, long, artType, long, lstIndex, long, animCode, l
 WRAP_WATCOM_FUNC3(BYTE*, art_frame_data, fo::FrmHeaderData*, frm, long, frameNum, long, rotation)
 WRAP_WATCOM_FUNC3(long, art_frame_width, fo::FrmHeaderData*, frm, long, frameNum, long, rotation)
 WRAP_WATCOM_FUNC3(long, art_frame_length, fo::FrmHeaderData*, frm, long, frameNum, long, rotation)
-WRAP_WATCOM_FUNC2(fo::FrmHeaderData*, art_ptr_lock, long, frmId, DWORD*, lockPtr)
+WRAP_WATCOM_FUNC5(long, art_frame_width_length, fo::FrmHeaderData*, frm, long, frameNum, long, rotation, long*, widthPtr, long*, heightPtr)
+WRAP_WATCOM_FUNC2(fo::FrmFile*, art_ptr_lock, long, frmId, DWORD*, lockPtr)
 WRAP_WATCOM_FUNC4(BYTE*, art_ptr_lock_data, long, frmId, long, frameNum, long, rotation, DWORD*, lockPtr)
 WRAP_WATCOM_FUNC4(BYTE*, art_lock, long, frmId, DWORD*, lockPtr, long*, widthOut, long*, heightOut)
 WRAP_WATCOM_FUNC1(long, art_ptr_unlock, DWORD, lockId)
@@ -104,6 +105,7 @@ WRAP_WATCOM_FUNC1(long, critter_kill_count_type, fo::GameObject*, critter)
 WRAP_WATCOM_FUNC1(const char*, critter_name, fo::GameObject*, critter) // Returns the name of the critter
 WRAP_WATCOM_FUNC1(void, critter_pc_set_name, const char*, newName) // Change the name of playable character
 WRAP_WATCOM_FUNC1(long, critterIsOverloaded, fo::GameObject*, critter)
+WRAP_WATCOM_FUNC4(void, datafileConvertData, unsigned char*, data, unsigned char*, palette, long, width, long, height)
 WRAP_WATCOM_FUNC1(void, display_print, const char*, msg) // Displays message in main UI console window
 WRAP_WATCOM_FUNC0(void, display_stats)
 WRAP_WATCOM_FUNC2(void, endgame_load_palette, long, artType, long, fid)
@@ -176,6 +178,7 @@ WRAP_WATCOM_FUNC2(long, item_w_subtype, fo::GameObject*, item, long, hitMode)
 WRAP_WATCOM_FUNC1(long, item_weight, fo::GameObject*, item)
 WRAP_WATCOM_FUNC2(long, light_get_tile, long, elevation, long, tileNum) // Returns light level at given tile
 WRAP_WATCOM_FUNC2(long, load_frame, const char*, filename, fo::FrmFile**, frmPtr)
+WRAP_WATCOM_FUNC4(unsigned char*, loadPCX, const char*, fileName, long*, width, long*, height, unsigned char*, palette)
 WRAP_WATCOM_FUNC1(fo::Program*, loadProgram, const char*, fileName)
 WRAP_WATCOM_FUNC1(const char*, map_get_short_name, long, mapID)
 WRAP_WATCOM_FUNC2(void, MapDirErase, const char*, folder, const char*, ext)

--- a/sfall/FalloutEngine/Variables_def.h
+++ b/sfall/FalloutEngine/Variables_def.h
@@ -171,6 +171,7 @@ VAR_(optionsButtonUp1,           DWORD)
 VAR_(optionsButtonUpKey,         DWORD)
 VARC(optnwin,                    DWORD)
 VAR_(outlined_object,            fo::GameObject*)
+VARA(pal,                        unsigned char, 0x300)
 VAR_(partyMemberAIOptions,       DWORD)
 VAR_(partyMemberCount,           DWORD)
 VAR_(partyMemberLevelUpInfoList, DWORD*)
@@ -277,3 +278,4 @@ VAR_(YellowColor,                BYTE)
 #undef VAR2
 #undef VAR3
 #undef VARD
+#undef VARF

--- a/sfall/IniReader.h
+++ b/sfall/IniReader.h
@@ -69,7 +69,7 @@ public:
 	void init();
 	void clearCache();
 
-	DWORD modifiedIni() { return _modifiedIni; }
+	DWORD modifiedIni() const { return _modifiedIni; }
 
 	const char* getConfigFile();
 	void setDefaultConfigFile();

--- a/sfall/Modules/HeroAppearance.cpp
+++ b/sfall/Modules/HeroAppearance.cpp
@@ -517,7 +517,7 @@ static void surface_draw(long width, long height, long fromWidth, long fromX, lo
 static void DrawBody(long critNum, BYTE* surface, long x, long y, long toWidth) {
 	DWORD critFrmLock;
 
-	fo::FrmHeaderData *critFrm = fo::func::art_ptr_lock(BuildFrmId(1, critNum), &critFrmLock);
+	fo::FrmFile *critFrm = fo::func::art_ptr_lock(BuildFrmId(1, critNum), &critFrmLock);
 	DWORD critWidth = fo::func::art_frame_width(critFrm, 0, charRotOri);
 	DWORD critHeight = fo::func::art_frame_length(critFrm, 0, charRotOri);
 	BYTE* critSurface = fo::func::art_frame_data(critFrm, 0, charRotOri);

--- a/sfall/Modules/LoadOrder.cpp
+++ b/sfall/Modules/LoadOrder.cpp
@@ -543,7 +543,7 @@ static void RemoveSavFiles() {
 
 static DWORD aliasFID = -1;
 
-static void __declspec(naked) art_get_name_hook() {
+static void __declspec(naked) art_alias_fid_hook() {
 	__asm {
 		call fo::funcoffs::art_alias_fid_;
 		cmp  eax, -1;
@@ -659,7 +659,7 @@ void LoadOrder::init() {
 
 	// Redefined behavior for replacing art aliases for critters
 	// first check the existence of the art file of the current critter and then replace the art alias if file not found
-	HookCall(0x419440, art_get_name_hook);
+	HookCall(0x419440, art_alias_fid_hook);
 	SafeWrite16(0x419521, 0x003B); // jmp 0x419560
 	if (IniReader::GetConfigInt("Misc", "EnableHeroAppearanceMod", 0) <= 0) { // Hero Appearance mod uses an alternative code
 		MakeCall(0x419560, art_get_name_hack);

--- a/sfall/Modules/Scripting/Arrays.h
+++ b/sfall/Modules/Scripting/Arrays.h
@@ -204,7 +204,7 @@ ScriptValue GetArrayKey(DWORD id, int index);
 ScriptValue GetArray(DWORD id, const ScriptValue& key);
 
 // set array element by index or key
-void SetArray(DWORD id, const ScriptValue& key, const ScriptValue& val, bool allowUnset);
+void SetArray(DWORD id, const ScriptValue& key, const ScriptValue& val, bool allowUnset = true);
 
 // number of elements in list or pairs in map
 int LenArray(DWORD id);

--- a/sfall/Modules/Scripting/Handlers/Interface.h
+++ b/sfall/Modules/Scripting/Handlers/Interface.h
@@ -27,6 +27,8 @@ namespace script
 
 class OpcodeContext;
 
+void ClearInterfaceArtCache();
+
 // input_functions
 void __declspec() op_input_funcs_available();
 
@@ -110,6 +112,8 @@ void mf_set_window_flag(OpcodeContext&);
 void mf_draw_image(OpcodeContext&);
 
 void mf_draw_image_scaled(OpcodeContext&);
+
+void mf_art_frame_data(OpcodeContext&);
 
 void mf_interface_art_draw(OpcodeContext&);
 

--- a/sfall/Modules/Scripting/Handlers/Metarule.cpp
+++ b/sfall/Modules/Scripting/Handlers/Metarule.cpp
@@ -75,6 +75,7 @@ static const SfallMetarule metarules[] = {
 	{"add_g_timer_event",         mf_add_g_timer_event,         2, 2, -1, {ARG_INT, ARG_INT}},
 	{"add_trait",                 mf_add_trait,                 1, 1, -1, {ARG_INT}},
 	{"art_cache_clear",           mf_art_cache_flush,           0, 0},
+	{"art_frame_data",            mf_art_frame_data,            1, 3,  0, {ARG_INTSTR, ARG_INT, ARG_INT}},
 	{"attack_is_aimed",           mf_attack_is_aimed,           0, 0},
 	{"car_gas_amount",            mf_car_gas_amount,            0, 0},
 	{"combat_data",               mf_combat_data,               0, 0},

--- a/sfall/Modules/Scripting/Opcodes.cpp
+++ b/sfall/Modules/Scripting/Opcodes.cpp
@@ -293,6 +293,7 @@ void Opcodes::InitNew() {
 		PipboyAvailableRestore();
 		ForceEncounterRestore(); // restore if the encounter did not happen
 		ResetIniCache();
+		ClearInterfaceArtCache();
 	};
 
 	if (int unsafe = IniReader::GetIntDefaultConfig("Debugging", "AllowUnsafeScripting", 0)) {

--- a/sfall/Modules/Tiles.cpp
+++ b/sfall/Modules/Tiles.cpp
@@ -143,13 +143,13 @@ exit:
 	}
 	long listID = listPos - tiles->total;
 
-	fo::FrmFile frame;
+	fo::TileFrmFile frame;
 	fo::func::db_fseek(artFile, 0, SEEK_SET);
 	fo::func::db_freadByteCount(artFile, (BYTE*)&frame, 74);
 
-	frame.height = ByteSwapW(36);
-	frame.width = ByteSwapW(80);
-	frame.frameSize = ByteSwapD(80 * 36);
+	frame.frameHeader.height = ByteSwapW(36);
+	frame.frameHeader.width = ByteSwapW(80);
+	frame.frameHeader.size = ByteSwapD(80 * 36);
 	frame.frameAreaSize = ByteSwapD(80 * 36 + 12);
 
 	for (int y = 0; y < ySize; y++) {


### PR DESCRIPTION
- Fix inconsistent and duplicate FRM-related struct definitions
- Clean up code, especially around using PCX files
- When FID is used, read FRM directly from ArtCache instead of unnecessary loading from disk
- When path is used, cache loaded FRM/PCX files
- Add art_frame_data to read FRM/PCX size by FID/filename