### PR TITLE
WorldMapHealingRatePatch & set_world_map_heal_time metarule

### DIFF
--- a/artifacts/ddraw.ini
+++ b/artifacts/ddraw.ini
@@ -279,9 +279,6 @@ WorldMapDelay2=66
 WorldMapEncounterFix=0
 WorldMapEncounterRate=5
 
-;Set to 1 to use game ticks instead of system ticks when calculating how often party should be healed when traveling.
-WorldMapHealingRatePatch=1
-
 ;The number of slots available in the locations list panel of the world map
 ;Set to 0 to leave the default unchanged (i.e. 17). The maximum is 127
 ;Setting this greater than 17 requires a replacement WMTABS.frm file in art\intrface\, or you'll get glitched graphics

--- a/artifacts/ddraw.ini
+++ b/artifacts/ddraw.ini
@@ -279,6 +279,9 @@ WorldMapDelay2=66
 WorldMapEncounterFix=0
 WorldMapEncounterRate=5
 
+;Set to 1 to use game ticks instead of system ticks when calculating how often party should be healed when traveling.
+WorldMapHealingRatePatch=1
+
 ;The number of slots available in the locations list panel of the world map
 ;Set to 0 to leave the default unchanged (i.e. 17). The maximum is 127
 ;Setting this greater than 17 requires a replacement WMTABS.frm file in art\intrface\, or you'll get glitched graphics

--- a/artifacts/scripting/functions.yml
+++ b/artifacts/scripting/functions.yml
@@ -1427,6 +1427,15 @@
     detail: void set_rest_heal_time(int time)
     doc: 'Sets the time interval in minutes for healing during resting. The default is 180. Note: The interval will be reset each time the player reloads the game.'
     macro: sfall.h
+  - name: set_world_map_heal_time
+    detail: void set_world_map_heal_time(int time)
+    doc: |
+      Sets the time interval in minutes for healing during worldmap travel. The default is 180.
+      - requires WorldMapHealingRatePatch to be enabled
+      - passing 0 will revert to 1 second per real time (vanilla behavior)
+      - passing -1 will disable healing during travel
+      - the interval will be reset each time the player reloads the game
+    macro: sfall.h
   - name: set_rest_mode
     detail: void set_rest_mode(int flags)
     doc: 'Sets the bit flags for the rest mode (see `RESTMODE_*` constants in **sfall.h**). Passing 0 will reset the rest mode. It will also be reset each time the player reloads the game.'

--- a/artifacts/scripting/functions.yml
+++ b/artifacts/scripting/functions.yml
@@ -1427,11 +1427,10 @@
     detail: void set_rest_heal_time(int time)
     doc: 'Sets the time interval in minutes for healing during resting. The default is 180. Note: The interval will be reset each time the player reloads the game.'
     macro: sfall.h
-  - name: set_world_map_heal_time
-    detail: void set_world_map_heal_time(int time)
+  - name: set_worldmap_heal_time
+    detail: void set_worldmap_heal_time(int time)
     doc: |
-      Sets the time interval in minutes for healing during worldmap travel. The default is 180.
-      - requires WorldMapHealingRatePatch to be enabled
+      Sets the time interval in minutes for healing during worldmap travel.
       - passing 0 will revert to 1 second per real time (vanilla behavior)
       - passing -1 will disable healing during travel
       - the interval will be reset each time the player reloads the game

--- a/artifacts/scripting/headers/sfall.h
+++ b/artifacts/scripting/headers/sfall.h
@@ -395,6 +395,7 @@
 #define set_unique_id(obj)                                      sfall_func1("set_unique_id", obj)
 #define set_unjam_locks_time(time)                              sfall_func1("set_unjam_locks_time", time)
 #define set_window_flag(winID, flag, value)                     sfall_func3("set_window_flag", winID, flag, value)
+#define set_world_map_heal_time(time)                           sfall_func1("set_world_map_heal_time", time)
 #define show_win                                                sfall_func0("show_window")
 #define show_window(winName)                                    sfall_func1("show_window", winName)
 #define signal_close_game                                       sfall_func0("signal_close_game")

--- a/artifacts/scripting/headers/sfall.h
+++ b/artifacts/scripting/headers/sfall.h
@@ -395,7 +395,7 @@
 #define set_unique_id(obj)                                      sfall_func1("set_unique_id", obj)
 #define set_unjam_locks_time(time)                              sfall_func1("set_unjam_locks_time", time)
 #define set_window_flag(winID, flag, value)                     sfall_func3("set_window_flag", winID, flag, value)
-#define set_world_map_heal_time(time)                           sfall_func1("set_world_map_heal_time", time)
+#define set_worldmap_heal_time(time)                            sfall_func1("set_worldmap_heal_time", time)
 #define show_win                                                sfall_func0("show_window")
 #define show_window(winName)                                    sfall_func1("show_window", winName)
 #define signal_close_game                                       sfall_func0("signal_close_game")

--- a/sfall/Modules/Scripting/Handlers/Metarule.cpp
+++ b/sfall/Modules/Scripting/Handlers/Metarule.cpp
@@ -151,6 +151,7 @@ static const SfallMetarule metarules[] = {
 	{"set_outline",               mf_set_outline,               2, 2, -1, {ARG_OBJECT, ARG_INT}},
 	{"set_quest_failure_value",   mf_set_quest_failure_value,   2, 2, -1, {ARG_INT, ARG_INT}},
 	{"set_rest_heal_time",        mf_set_rest_heal_time,        1, 1, -1, {ARG_INT}},
+	{"set_world_map_heal_time",   mf_set_world_map_heal_time,   1, 1, -1, {ARG_INT}},
 	{"set_rest_mode",             mf_set_rest_mode,             1, 1, -1, {ARG_INT}},
 	{"set_scr_name",              mf_set_scr_name,              0, 1, -1, {ARG_STRING}},
 	{"set_selectable_perk_npc",   mf_set_selectable_perk_npc,   5, 5, -1, {ARG_OBJECT, ARG_STRING, ARG_INT, ARG_INT, ARG_STRING}},

--- a/sfall/Modules/Scripting/Handlers/Metarule.cpp
+++ b/sfall/Modules/Scripting/Handlers/Metarule.cpp
@@ -151,7 +151,7 @@ static const SfallMetarule metarules[] = {
 	{"set_outline",               mf_set_outline,               2, 2, -1, {ARG_OBJECT, ARG_INT}},
 	{"set_quest_failure_value",   mf_set_quest_failure_value,   2, 2, -1, {ARG_INT, ARG_INT}},
 	{"set_rest_heal_time",        mf_set_rest_heal_time,        1, 1, -1, {ARG_INT}},
-	{"set_world_map_heal_time",   mf_set_world_map_heal_time,   1, 1, -1, {ARG_INT}},
+	{"set_worldmap_heal_time",    mf_set_worldmap_heal_time,    1, 1, -1, {ARG_INT}},
 	{"set_rest_mode",             mf_set_rest_mode,             1, 1, -1, {ARG_INT}},
 	{"set_scr_name",              mf_set_scr_name,              0, 1, -1, {ARG_STRING}},
 	{"set_selectable_perk_npc",   mf_set_selectable_perk_npc,   5, 5, -1, {ARG_OBJECT, ARG_STRING, ARG_INT, ARG_INT, ARG_STRING}},

--- a/sfall/Modules/Scripting/Handlers/Worldmap.cpp
+++ b/sfall/Modules/Scripting/Handlers/Worldmap.cpp
@@ -202,7 +202,7 @@ void mf_set_rest_heal_time(OpcodeContext& ctx) {
 	Worldmap::SetRestHealTime(ctx.arg(0).rawValue());
 }
 
-void mf_set_world_map_heal_time(OpcodeContext& ctx) {
+void mf_set_worldmap_heal_time(OpcodeContext& ctx) {
 	Worldmap::SetWorldMapHealTime(ctx.arg(0).rawValue());
 }
 

--- a/sfall/Modules/Scripting/Handlers/Worldmap.cpp
+++ b/sfall/Modules/Scripting/Handlers/Worldmap.cpp
@@ -202,6 +202,10 @@ void mf_set_rest_heal_time(OpcodeContext& ctx) {
 	Worldmap::SetRestHealTime(ctx.arg(0).rawValue());
 }
 
+void mf_set_world_map_heal_time(OpcodeContext& ctx) {
+	Worldmap::SetWorldMapHealTime(ctx.arg(0).rawValue());
+}
+
 void mf_set_rest_mode(OpcodeContext& ctx) {
 	Worldmap::SetRestMode(ctx.arg(0).rawValue());
 }

--- a/sfall/Modules/Scripting/Handlers/Worldmap.h
+++ b/sfall/Modules/Scripting/Handlers/Worldmap.h
@@ -50,7 +50,7 @@ void mf_get_map_enter_position(OpcodeContext&);
 
 void mf_set_rest_heal_time(OpcodeContext&);
 
-void mf_set_world_map_heal_time(OpcodeContext&);
+void mf_set_worldmap_heal_time(OpcodeContext&);
 
 void mf_set_rest_mode(OpcodeContext&);
 

--- a/sfall/Modules/Scripting/Handlers/Worldmap.h
+++ b/sfall/Modules/Scripting/Handlers/Worldmap.h
@@ -50,6 +50,8 @@ void mf_get_map_enter_position(OpcodeContext&);
 
 void mf_set_rest_heal_time(OpcodeContext&);
 
+void mf_set_world_map_heal_time(OpcodeContext&);
+
 void mf_set_rest_mode(OpcodeContext&);
 
 void mf_set_rest_on_map(OpcodeContext&);

--- a/sfall/Modules/Worldmap.cpp
+++ b/sfall/Modules/Worldmap.cpp
@@ -61,7 +61,7 @@ static DWORD worldMapTicks;
 
 static DWORD WorldMapEncounterRate;
 
-static constexpr long WorldMapHealingDefaultInterval = -1;
+static constexpr long WorldMapHealingDefaultInterval = 0;
 // Healing interval in game time
 static long worldMapHealingInterval = WorldMapHealingDefaultInterval;
 static DWORD worldMapLastHealTime;

--- a/sfall/Modules/Worldmap.h
+++ b/sfall/Modules/Worldmap.h
@@ -36,6 +36,7 @@ public:
 
 	static void SetCarInterfaceArt(DWORD artIndex);
 	static void SetRestHealTime(DWORD minutes);
+	static void SetWorldMapHealTime(long minutes);
 	static void SetRestMode(DWORD mode);
 	static void SetRestMapLevel(int mapId, long elev, bool canRest);
 	static long __fastcall GetRestMapLevel(long elev, int mapId);


### PR DESCRIPTION
Fixes bug: healing time on worldmap is tied to real time clock, instead of game time.

Healing Rate stat description says that outside of rest, you should get 1 HP "at the end of each day", whatever that means. ~~But I decided to use default value of 6 hours because it works better with short travels (less than 1 period) and matches rest healing timer.~~