### PR TITLE
Docs: remove misleading parens from functions without args, they should not be present

### DIFF
--- a/artifacts/scripting/functions.yml
+++ b/artifacts/scripting/functions.yml
@@ -174,7 +174,7 @@
     detail: void set_available_skill_points(int value)
     opcode: 0x8244
   - name: get_available_skill_points
-    detail: int get_available_skill_points()
+    detail: int get_available_skill_points
     opcode: 0x8245
 
   - name: set_skill_max
@@ -239,10 +239,10 @@
     detail: void set_shader_texture(int ID, string param, int texID)
     opcode: 0x81b2
   - name: get_screen_width
-    detail: int get_screen_width()
+    detail: int get_screen_width
     opcode: 0x8220
   - name: get_screen_height
-    detail: int get_screen_height()
+    detail: int get_screen_height
     opcode: 0x8221
   - name: set_palette
     detail: void set_palette(string path)
@@ -352,11 +352,11 @@
     opcode: 0x81be
     doc: Used to change the title of the "select a perk" box, or by using "" it will be set back to the default.
   - name: hide_real_perks
-    detail: void hide_real_perks()
+    detail: void hide_real_perks
     opcode: 0x81bf
     doc: Prevent the "select a perk" box from displaying any of the original 119 perks.
   - name: show_real_perks
-    detail: void show_real_perks()
+    detail: void show_real_perks
     opcode: 0x81c0
     doc: Reverts the effect os `hide_real_perks`.
   - name: perk_add_mode
@@ -364,7 +364,7 @@
     opcode: 0x81c3
     doc: Modifies what happens when a fake perk is selected from the perks dialog. It is treated as a set of flags - if bit 1 is set then it is added to the player's traits, if bit 2 is set it is added to the player's perks, and if bit 3 is set it is removed from the list of selectable perks. The default is 0x2.
   - name: clear_selectable_perks
-    detail: void clear_selectable_perks()
+    detail: void clear_selectable_perks
     opcode: 0x81c4
     doc: Restores the "select a perk" box to its default state.
 
@@ -492,10 +492,10 @@
     detail: void set_map_enter_position(int tile, int elevation, int rotation)
     doc: Overrides the players entry position when entering the map through exit grids. Setting the tile to 0 will put the player on the start hex (default tile and elevation) of the map. Works only in `map_enter_p_proc` procedure.
   - name: get_map_enter_position
-    detail: array get_map_enter_position()
+    detail: array get_map_enter_position
     doc: "Returns an array of the player's position data (index: 0 - tile, 1 - elevation, 2 - rotation) when entering the map through exit grids. If entering from the world map, the tile value will be -1. Should be called in `map_enter_p_proc` procedure to get the correct position data."
   - name: exec_map_update_scripts
-    detail: void exec_map_update_scripts()
+    detail: void exec_map_update_scripts
     doc: Executes `map_update_p_proc` for all objects on map and global/hook scripts as well.
     macro: sfall.h
   - name: set_terrain_name
@@ -538,10 +538,10 @@
   doc: The mapper manual lists the functions `world_map_x_pos` and `world_map_y_pos`, which supposedly return the player's x and y positions on the world map. `get_world_map_x/y_pos` are included here anyway, because I was unable to get those original functions to work, or even to find any evidence that they existed in game.
   items:
   - name: get_world_map_x_pos
-    detail: int get_world_map_x_pos()
+    detail: int get_world_map_x_pos
     opcode: 0x8173
   - name: get_world_map_y_pos
-    detail: int get_world_map_y_pos()
+    detail: int get_world_map_y_pos
     opcode: 0x8174
   - name: set_world_map_pos
     detail: void set_world_map_pos(int x, int y)
@@ -551,7 +551,7 @@
 - name: Audio
   items:
   - name: eax_available
-    detail: int eax_available()
+    detail: int eax_available
     opcode: 0x81a3
     doc: Obsolete since sfall 2.1a. Always returns 0.
   - name: set_eax_environment
@@ -593,13 +593,13 @@
   parent: Sfall
   items:
   - name: sfall_ver_major
-    detail: int sfall_ver_major()
+    detail: int sfall_ver_major
     opcode: 0x8210
   - name: sfall_ver_minor
-    detail: int sfall_ver_minor()
+    detail: int sfall_ver_minor
     opcode: 0x8211
   - name: sfall_ver_build
-    detail: int sfall_ver_build()
+    detail: int sfall_ver_build
     opcode: 0x8212
 
 - name: Math
@@ -674,13 +674,13 @@
     detail: void tap_key(int dxScancode)
     opcode: 0x8162
   - name: get_mouse_x
-    detail: int get_mouse_x()
+    detail: int get_mouse_x
     opcode: 0x821c
   - name: get_mouse_y
-    detail: int get_mouse_y()
+    detail: int get_mouse_y
     opcode: 0x821d
   - name: get_mouse_buttons
-    detail: int get_mouse_buttons()
+    detail: int get_mouse_buttons
     doc: Returns the number of the mouse button that is currently pressed (1 - left, 2 - right, 3 - left+right, 4 - middle, 0 otherwise).
     opcode: 0x821e
 
@@ -822,7 +822,7 @@
     detail: void refresh_pc_art
     opcode: 0x8227
   - name: art_cache_clear
-    detail: void art_cache_clear()
+    detail: void art_cache_clear
     doc: Clears the cache of FRM image files loaded into memory.
     macro: sfall.h
 
@@ -855,7 +855,7 @@
     doc: Returns an array of all objects at given tile. It will include any hidden, dead or system objects (like cursor), so make sure to check properly when iterating.
     opcode: 0x8270
   - name: tile_refresh_display
-    detail: void tile_refresh_display()
+    detail: void tile_refresh_display
     doc: Redraws the game scene (tiles, walls, objects, etc.).
   - name: obj_blocking_tile
     detail: ObjectPtr obj_blocking_tile(int tileNum, int elevation, int blockingType)
@@ -889,7 +889,7 @@
 - name: Other
   items:
   - name: input_funcs_available
-    detail: int input_funcs_available()
+    detail: int input_funcs_available
     opcode: 0x816b
     doc: (DEPRECATED) The input functions are only available if the user has the input hook turned on in `ddraw.ini`. Use `input_funcs_available` to check.
   - name: get_year
@@ -945,10 +945,10 @@
     detail: int get_npc_level(string npc)
     opcode: 0x8241
   - name: get_viewport_x
-    detail: int get_viewport_x()
+    detail: int get_viewport_x
     opcode: 0x81a6
   - name: get_viewport_y
-    detail: int get_viewport_y()
+    detail: int get_viewport_y
     opcode: 0x81a7
   - name: set_viewport_x
     detail: void set_viewport_x(int view_x)
@@ -966,7 +966,7 @@
     opcode: 0x81e6
     doc: Alters the AC bonus you receive per unused action point at the end of your turn in combat. To allow for fractional values, the value given if divided by 4. (Hence the default value is 4 and not 1.)
   - name: get_unspent_ap_bonus
-    detail: int get_unspent_ap_bonus()
+    detail: int get_unspent_ap_bonus
     doc: Gets the AC bonus you receive per unused action point at the end of your turn in combat. To allow for fractional values, the value given if divided by 4. (Hence the default value is 4 and not 1.)
     opcode: 0x81e7
   - name: set_unspent_ap_perk_bonus
@@ -974,12 +974,12 @@
     opcode: 0x81e8
     doc: Similar to `set_unspent_ap_bonus`, but effects the extra AC granted by the H2H Evade perk. (The default value of this is also 4, equivalent to doubling the original bonus.
   - name: get_unspent_ap_perk_bonus
-    detail: int get_unspent_ap_perk_bonus()
+    detail: int get_unspent_ap_perk_bonus
     opcode: 0x81e9
     doc: Similar to `get_unspent_ap_bonus`, but accounts for the extra AC granted by the H2H Evade perk. (The default value of this is also 4, equivalent to doubling the original bonus.
 
   - name: nb_create_char
-    detail: int nb_create_char()
+    detail: int nb_create_char
     opcode: 0x81f6
     doc: (DEPRECATED) Reserved for the brotherhood tactical training mod, and should be avoided. Not implemented, always returns 0.
 
@@ -996,16 +996,16 @@
     detail: void hero_select_win(int)
     opcode: 0x8213
   - name: stop_game
-    detail: void stop_game()
+    detail: void stop_game
     opcode: 0x8222
   - name: resume_game
-    detail: void resume_game()
+    detail: void resume_game
     opcode: 0x8223
   - name: create_message_window
     detail: void create_message_window(string message)
     opcode: 0x8224
   - name: get_light_level
-    detail: int get_light_level()
+    detail: int get_light_level
     opcode: 0x8226
     doc: Returns ambient light level in range 0..65536. The value returned by get_light_level may not exactly match that set by `set_light_level`, as `set_light_level` applies modifiers from the Night Vision perk.
 
@@ -1019,16 +1019,16 @@
     detail: void set_inven_ap_cost(int cost)
     opcode: 0x824d
   - name: game_loaded
-    detail: int game_loaded()
+    detail: int game_loaded
     doc: Returns 1 the first time it is called after a new game or game load, and 0 any time after. It works on an individual basis for each script, so one script wont interfere with others. Its primary use is for global scripts, so that they know when to call `set_global_script_repeat`, but it can be called from normal scripts too.
     opcode: 0x8164
 
   - name: get_game_mode
-    detail: int get_game_mode()
+    detail: int get_game_mode
     doc: A more flexible version of in_world_map. It will return a set of flags indicating which mode the game is currently in. These flags are the same as those used in the `set_shader_mode function`.
     opcode: 0x81af
   - name: get_uptime
-    detail: int get_uptime()
+    detail: int get_uptime
     doc: Just a wrapper around the windows GetTickCount() function. It's useful for making time fade effects in shaders, since they already have access to the current tick count.
     opcode: 0x81b3
 
@@ -1186,7 +1186,7 @@
     doc: Sets the text messages and colors for custom notification boxes to the interface without the need to add messages to `intrface.msg` and set up the font colors in `ddraw.ini`. Tag value is the same as used in `show_iface_tag`, `hide_iface_tag`, and `is_iface_tag_active`. The valid range is from 5 to (4 + the value of BoxBarCount in `ddraw.ini`) or the number of the last custom box added using the `add_iface_tag` function. The text is limited to 19 characters.
     macro: sfall.h
   - name: add_iface_tag
-    detail: void add_iface_tag()
+    detail: void add_iface_tag
     doc: Adds one custom box to the current boxes, and returns the number of the added tag (-1 if the tags limit is exceeded. The maximum number of boxes is limited to 126 tags.
     macro: sfall.h
 
@@ -1207,15 +1207,15 @@
   parent: Hooks # normal page
   items:
   - name: init_hook
-    detail: int init_hook()
+    detail: int init_hook
     doc: The hook script equivalent of `game_loaded`; it returns 1 when the script is loaded for the first time or when the player reloads the game, and 0 otherwise.
     opcode: 0x81ea
   - name: get_sfall_arg
-    detail: mixed get_sfall_arg()
+    detail: mixed get_sfall_arg
     doc: Gets the next argument from sfall. Each time it's called it returns the next argument, or otherwise it returns 0 if there are no more arguments left. You can arbitrarily get the value of any argument using the `sfall_func1("get_sfall_arg_at", argNum)` function.
     opcode: 0x81e4
   - name: get_sfall_args
-    detail: int get_sfall_args()
+    detail: int get_sfall_args
     doc: Returns all hook arguments as a new temp array.
     opcode: 0x823c
   - name: get_sfall_arg_at
@@ -1583,7 +1583,7 @@
 - name: Combat
   items:
   - name: attack_is_aimed
-    detail: bool attack_is_aimed()
+    detail: bool attack_is_aimed
     doc: Returns 1 if the aimed attack mode is selected, 0 otherwise.
     macro: sfall.h
 
@@ -1664,7 +1664,7 @@
     macro: sfall.h
 
   - name: get_combat_free_move
-    detail: int get_combat_free_move()
+    detail: int get_combat_free_move
     doc: Returns available "bonus move" points of the current critter's turn. For NPCs, this is always 0 unless changed by `set_combat_free_move`
     macro: sfall.h
 
@@ -1683,7 +1683,7 @@
     opcode: 0x81b6
     doc: Changes the current town index for the player's car.
   - name: car_gas_amount
-    detail: int car_gas_amount()
+    detail: int car_gas_amount
     doc: |
       Returns the current amount of fuel in player's car (between 0 and 80000).
       To change fuel amount, use vanilla function: `metarule(METARULE_GIVE_CAR_GAS, amount)` - `amount` can be positive or negative.
@@ -1774,7 +1774,7 @@
       macro: sfall.h
 
     - name: get_window_under_mouse
-      detail: int get_window_under_mouse()
+      detail: int get_window_under_mouse
       opcode: 0x821f
       doc: "Returns the internal ID of the top-most window under mouse cursor."
     - name: create_win
@@ -1835,7 +1835,7 @@
   parent: Interface
   items:
   - name: outlined_object
-    detail: ObjectPtr outlined_object()
+    detail: ObjectPtr outlined_object
     doc: Returns an object that is currently highlighted by hovering the mouse above it.
     macro: sfall.h
   - name: get_outline
@@ -1854,7 +1854,7 @@
   parent: Interface
   items:
   - name: intface_is_hidden
-    detail: bool intface_is_hidden()
+    detail: bool intface_is_hidden
     macro: sfall.h
     doc: Returns 1 if interface is currently hidden, 0 otherwise.
   - name: intface_redraw
@@ -1865,11 +1865,11 @@
       - redraws main game interface, useful to reflect changes after directly changing current player weapons or stats
       - `winType`: the type number of the interface window (see `WINTYPE_*` constants in **sfall.h**). Pass `-1` to redraw all interface windows.
   - name: intface_hide
-    detail: void intface_hide()
+    detail: void intface_hide
     doc: Hides main interface.
     macro: sfall.h
   - name: intface_show
-    detail: void intface_show()
+    detail: void intface_show
     doc: Shows main interface.
     macro: sfall.h
 
@@ -1877,7 +1877,7 @@
   parent: Interface
   items:
   - name: display_stats
-    detail: void display_stats()
+    detail: void display_stats
     doc: |
       - Updates player's stats in the inventory display window or on the character screen.
       - NOTE: works only when the interface window is opened
@@ -1901,7 +1901,7 @@
   parent: Interface
   items:
   - name: get_cursor_mode
-    detail: int get_cursor_mode()
+    detail: int get_cursor_mode
     doc: 'Returns the current cursor mode. Values: 0 - movement cursor, 1 - command cursor, 2 - targeting cursor, 4 to 10 are Skilldex skills (yellow targeting cursor).'
     macro: sfall.h
   - name: set_cursor_mode
@@ -1993,7 +1993,7 @@
     doc: Take control of a given critter. Passing value 0 will reset control back to "real" dude.
     macro: sfall.h
   - name: real_dude_obj
-    detail: ObjectPtr real_dude_obj()
+    detail: ObjectPtr real_dude_obj
     doc: Returns the initial `dude_obj` after `set_dude_obj` was used.
     macro: sfall.h
 
@@ -2018,11 +2018,11 @@
     opcode: 0x8275
 
   - name: loot_obj
-    detail: ObjectPtr loot_obj()
+    detail: ObjectPtr loot_obj
     doc: Returns a pointer to the target object (container or critter) of the loot screen.
     macro: sfall.h
   - name: dialog_obj
-    detail: ObjectPtr dialog_obj()
+    detail: ObjectPtr dialog_obj
     doc: Returns a pointer to the object (critter) the player is having a conversation or bartering with.
     macro: sfall.h
 


### PR DESCRIPTION
From what I see, the parentheses after funcs with no args actually cause the compiler to fail.